### PR TITLE
Support for Kafka 3.4.0 + generic requests tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Configuration for Envoy is present in `kafka-all.yaml` (notice it requires 4 Kaf
 
 If Kafka brokers and Envoy are running with config mentioned below, then `./gradlew test` should work.
 
+If upgrading Kafka, you can use `compare.py` to figure out what changed.
+
 ## Requirements for broker-filter tests:
 
 * 1-node Kafka cluster on localhost:9292, advertising itself on localhost:19092 (what means Envoy)

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    def kafka_version = "3.3.1"
+    def kafka_version = "3.4.0"
     implementation("org.apache.kafka:kafka-clients:${kafka_version}")
 
     def slf4j_version = "1.7.32"

--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import re
+import requests
+import sys
+
+from os import listdir
+from os.path import isfile, join
+
+# Point this script at a directory containing two repos with Kafka sources, with different versions.
+# Basically a glorified diff.
+
+KAFKA_DATA_PATH='clients/src/main/resources/common/message'
+
+logging.basicConfig(stream = sys.stdout,
+                    format = '%(message)s',
+                    level = logging.INFO)
+logger = logging.getLogger('compare')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-r')
+    parser.add_argument('-v1')
+    parser.add_argument('-v2')
+    args = parser.parse_args(sys.argv[1:])
+    if args.r is None or args.v1 is None or args.v2 is None:
+        logger.info("Missing arguments: -r, -v1, -v2")
+        exit(1)
+    else:
+        run(args.r, args.v1, args.v2)
+
+
+def run(root: str, kafka_version_1: str, kafka_version_2: str):
+    path1 = '%s/%s/%s' % (root, kafka_version_1, KAFKA_DATA_PATH)
+    path2 = '%s/%s/%s' % (root, kafka_version_2, KAFKA_DATA_PATH)
+    logger.info('Comparing [%s] with [%s]', path1, path2)
+
+    # Response versions always match request versions so we only need to identify new request types.
+    files1 = [join(path1, f) for f in listdir(path1) if isfile(join(path1, f)) and f.endswith('Request.json')]
+    data1 = parse(files1)
+
+    files2 = [join(path2, f) for f in listdir(path2) if isfile(join(path2, f)) and f.endswith('Request.json')]
+    data2 = parse(files2)
+
+    outdated = [x for x in data1.keys() if x not in data2.keys()]
+    if outdated:
+        # This might need manual intervention - there's some API key that's no longer supported.
+        # But this should never happen as servers need to be backwards compatible.
+        raise ValueError('api key removed: ' + str(outdated))
+
+    keys = sorted(data2.keys())
+    for k in keys:
+        if k in data1.keys():
+            # Check request versions.
+            v1 = data1[k][1]
+            v2 = data2[k][1]
+            logger.debug("%s -> %s vs %s", k, v1, v2)
+            lastSupported1 = v1[-1]
+            lastSupported2 = v2[-1]
+            if lastSupported1 < lastSupported2:
+                # New request version (what we wanted to find).
+                logger.info("%s -> New versions in %s: new %s vs old %s", k, data2[k][0], lastSupported2, lastSupported1)
+            elif lastSupported1 == lastSupported2:
+                # No changes.
+                pass
+            else:
+                # Bad data?
+                logger.warn("%s -> older version supports higher version than new: %s / %s", k, lastSupported1, lastSupported2)
+                pass
+        else:
+            # New request type.
+            logger.info("%s -> New request type: %s", k, data2[k][0])
+
+
+# From Envoy - https://github.com/envoyproxy/envoy/blob/v1.25.1/contrib/kafka/filters/network/source/protocol/generator.py
+def parse(files):
+    result = {}
+    for input_file in files:
+        try:
+            with open(input_file, 'r') as fd:
+                raw_contents = fd.read()
+                without_comments = re.sub(r'\s*//.*\n', '\n', raw_contents)
+                without_empty_newlines = re.sub(
+                    r'^\s*$', '', without_comments, flags=re.MULTILINE)
+                message_spec = json.loads(without_empty_newlines)
+
+                message_type = message_spec['name']
+                api_key = message_spec['apiKey']
+                versions = parse_version_string(message_spec['validVersions'], 2 << 16 - 1)
+
+                result[api_key] = (message_type, versions)
+
+                #logger.info('%s %s %s', message_type, api_key, versions)
+        except Exception as e:
+            print('could not process %s' % input_file)
+            raise
+    return result
+
+
+# From Envoy - https://github.com/envoyproxy/envoy/blob/v1.25.1/contrib/kafka/filters/network/source/protocol/generator.py
+def parse_version_string(raw_versions, highest_possible_version):
+    if raw_versions.endswith('+'):
+        return range(int(raw_versions[:-1]), highest_possible_version + 1)
+    else:
+        if '-' in raw_versions:
+            tokens = raw_versions.split('-', 1)
+            return range(int(tokens[0]), int(tokens[1]) + 1)
+        else:
+            single_version = int(raw_versions)
+            return range(single_version, single_version + 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main/java/envoy/ReadHelper.java
+++ b/src/main/java/envoy/ReadHelper.java
@@ -1,0 +1,62 @@
+package envoy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads a response (its 4-byte length header and N following bytes).
+ *
+ * @author adam.kotwasinski
+ */
+public class ReadHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReadHelper.class);
+
+    private static final int HEADER_SIZE = 4;
+
+    public final ByteBuffer hb;
+    public ByteBuffer db;
+
+    private ReadHelper() {
+        this.hb = ByteBuffer.allocate(HEADER_SIZE);
+        this.db = null;
+    }
+
+    public void read(final SocketChannel channel)
+            throws IOException {
+
+        while (this.hb.hasRemaining()) {
+            channel.read(this.hb);
+        }
+        this.hb.flip();
+        final int dataLength = this.hb.getInt();
+        LOG.trace("Response length = {}", dataLength);
+
+        if (dataLength >= 0) {
+            this.db = ByteBuffer.allocate(dataLength);
+            while (this.db.hasRemaining()) {
+                channel.read(this.db);
+            }
+            this.db.flip();
+        }
+        else {
+            throw new IllegalArgumentException("No data: " + dataLength);
+        }
+    }
+
+    public static ByteBuffer receive(final SocketChannel channel) {
+        final ReadHelper rh = new ReadHelper();
+        try {
+            rh.read(channel);
+            return rh.db;
+        }
+        catch (final IOException e) {
+            throw new IllegalArgumentException("IO failure", e);
+        }
+    }
+
+}

--- a/src/test/java/envoy/broker/AllRequestsBrokerTest.java
+++ b/src/test/java/envoy/broker/AllRequestsBrokerTest.java
@@ -1,0 +1,82 @@
+package envoy.broker;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+
+import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.MessageSizeAccumulator;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * In this test suite, we just generate basic requests (fortunately there's a factory method for that) and send them upstream.
+ * Unfortunately we cannot wait for replies, as the upstream seems to hang on some malformed requests like PRODUCE.
+ *
+ * @author adam.kotwasinski
+ */
+public class AllRequestsBrokerTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AllRequestsBrokerTest.class);
+
+    // Manual verification: go to http://localhost:9901/stats and take a look at kafka.broker.request.* metrics.
+    // XXX automate this :)
+    @Test
+    public void shouldSendAllRequests()
+            throws Exception {
+
+        final SocketAddress address = new InetSocketAddress("localhost", 19092);
+        try (SocketChannel channel = SocketChannel.open(address)) {
+            int correlationId = 0;
+            for (final ApiKeys apiKey : ApiKeys.values()) {
+                LOG.info("Sending {}", apiKey);
+                sendRequest(channel, apiKey, apiKey.latestVersion(), correlationId++); // This should not fail.
+            }
+        }
+    }
+
+    private static void sendRequest(final SocketChannel channel,
+                                    final ApiKeys apiKey,
+                                    final short version,
+                                    final int correlationId)
+            throws Exception {
+
+        final ApiMessageType apiMessageType = ApiMessageType.fromApiKey(apiKey.id);
+        final ApiMessage data = apiMessageType.newRequest(); // Haha!
+        final RequestHeader header = new RequestHeader(apiKey, version, "", correlationId);
+
+        final ByteBuffer bytes = toBytes(header, data);
+        channel.write(bytes);
+    }
+
+    private static ByteBuffer toBytes(final RequestHeader header, final ApiMessage data) {
+
+        final short headerVersion = header.headerVersion();
+        final short apiVersion = header.apiVersion();
+
+        final ObjectSerializationCache serializationCache = new ObjectSerializationCache();
+
+        final MessageSizeAccumulator ms = new MessageSizeAccumulator();
+        header.data().addSize(ms, serializationCache, headerVersion);
+        data.addSize(ms, serializationCache, apiVersion);
+
+        final ByteBuffer bb = ByteBuffer.allocate(ms.sizeExcludingZeroCopy() + 4);
+        final ByteBufferAccessor bba = new ByteBufferAccessor(bb);
+
+        bba.writeInt(ms.totalSize());
+        header.data().write(bba, serializationCache, headerVersion);
+        data.write(bba, serializationCache, apiVersion);
+
+        bb.flip();
+
+        return bb;
+    }
+
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -11,5 +11,7 @@ log4j.logger.org.apache.kafka.common.utils.AppInfoParser=WARN
 log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=WARN
 # Kafka producer config
 log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=WARN
+# Kafka admin config
+log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=WARN
 # Metrics
 log4j.logger.org.apache.kafka.common.metrics.Metrics=WARN


### PR DESCRIPTION
* upgrades the Kafka clients dep to 3.4.0
* adds a new request test - we use some internal API to create "basic"/"trivial" requests and send them upstream and expect a response (it might be interesting in future to use to use some reflection to dumb fill in the fields just like I did with generated code for envoy)

Used for https://github.com/envoyproxy/envoy/pull/25491